### PR TITLE
use fflate instead of pako

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const pako = require('pako')
+const { unzlibSync } = require('fflate')
 const ndarray = require('ndarray')
 const ops = require('ndarray-ops')
 const { parallel } = require('async')
@@ -168,7 +168,7 @@ const zarr = (request) => {
   const parseChunk = (chunk, metadata) => {
     if (metadata.compressor) {
       if (metadata.compressor.id === 'zlib') {
-        chunk = pako.inflate(chunk)
+        chunk = unzlibSync(chunk)
       } else {
         throw new Error('compressor ' + metadata.compressor.id + ' is not supported')
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "async": "^2.6.2",
         "cartesian-product": "^2.1.2",
+        "fflate": "^0.7.1",
         "ndarray": "^1.0.18",
         "ndarray-ops": "^1.2.2",
         "ndarray-scratch": "^1.2.0",
@@ -214,6 +215,11 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.1.tgz",
+      "integrity": "sha512-VYM2Xy1gSA5MerKzCnmmuV2XljkpKwgJBKezW+495TTnTCh1x5HcYa1aH8wRU/MfTGhW4ziXqgwprgQUVl3Ohw=="
     },
     "node_modules/figures": {
       "version": "1.7.0",
@@ -1048,6 +1054,11 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "fflate": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.1.tgz",
+      "integrity": "sha512-VYM2Xy1gSA5MerKzCnmmuV2XljkpKwgJBKezW+495TTnTCh1x5HcYa1aH8wRU/MfTGhW4ziXqgwprgQUVl3Ohw=="
     },
     "figures": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "dependencies": {
     "async": "^2.6.2",
     "cartesian-product": "^2.1.2",
+    "fflate": "^0.7.1",
     "ndarray": "^1.0.18",
     "ndarray-ops": "^1.2.2",
     "ndarray-scratch": "^1.2.0",
-    "pako": "^1.0.10"
   },
   "devDependencies": {
     "prettier": "^2.4.1",


### PR DESCRIPTION
Small patch to swap [`fflate`](https://github.com/101arrowz/fflate) for `pako`. It appears to work as a drop in replacement (all tests pass), and promises a much smaller bundle sizes and faster performance. Win win!