### PR TITLE
use fflate

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { inflate } = require('pako')
+const { unzlibSync } = require('fflate')
 const ndarray = require('ndarray')
 const ops = require('ndarray-ops')
 const { parallel } = require('async')
@@ -183,9 +183,10 @@ const zarr = (request) => {
   // parse a single zarr chunk
   const parseChunk = (chunk, metadata) => {
     if (chunk) {
+      chunk = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
       if (metadata.compressor) {
         if (metadata.compressor.id === 'zlib') {
-          chunk = inflate(chunk)
+          chunk = unzlibSync(chunk)
         } else {
           throw new Error(
             'compressor ' + metadata.compressor.id + ' is not supported'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,23 @@
 {
   "name": "zarr-js",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zarr-js",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "async": "^2.6.2",
         "cartesian-product": "^2.1.2",
+        "fflate": "^0.7.3",
         "ndarray": "^1.0.18",
         "ndarray-ops": "^1.2.2",
-        "ndarray-scratch": "^1.2.0",
-        "pako": "^1.0.10"
+        "ndarray-scratch": "^1.2.0"
       },
       "devDependencies": {
+        "node-fetch": "^2.6.7",
         "prettier": "^2.4.1",
         "tap-spec": "^5.0.0",
         "tape": "^4.13.0"
@@ -215,6 +216,11 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.3.tgz",
+      "integrity": "sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw=="
     },
     "node_modules/figures": {
       "version": "1.7.0",
@@ -445,6 +451,26 @@
         "typedarray-pool": "^1.0.2"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -510,11 +536,6 @@
       "dependencies": {
         "wrappy": "1"
       }
-    },
-    "node_modules/pako": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
     },
     "node_modules/parse-ms": {
       "version": "1.0.1",
@@ -837,6 +858,12 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
     "node_modules/trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -862,6 +889,22 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -1049,6 +1092,11 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "fflate": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.3.tgz",
+      "integrity": "sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw=="
     },
     "figures": {
       "version": "1.7.0",
@@ -1243,6 +1291,15 @@
         "typedarray-pool": "^1.0.2"
       }
     },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -1293,11 +1350,6 @@
       "requires": {
         "wrappy": "1"
       }
-    },
-    "pako": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
     },
     "parse-ms": {
       "version": "1.0.1",
@@ -1570,6 +1622,12 @@
         }
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -1595,6 +1653,22 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "zarr-js",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "load chunked binary zarr files in javascript",
   "main": "index.js",
   "scripts": {
-    "test": "tape test.js | tap-spec",
+    "test": "tape test.js local remote | tap-spec",
+    "test-local": "tape test.js local | tap-spec",
+    "test-remote": "tape test.js remote | tap-spec",
     "prettier": "prettier --write index.js"
   },
   "author": "freeman-lab",
@@ -12,12 +14,13 @@
   "dependencies": {
     "async": "^2.6.2",
     "cartesian-product": "^2.1.2",
+    "fflate": "^0.7.3",
     "ndarray": "^1.0.18",
     "ndarray-ops": "^1.2.2",
-    "ndarray-scratch": "^1.2.0",
-    "pako": "^1.0.10"
+    "ndarray-scratch": "^1.2.0"
   },
   "devDependencies": {
+    "node-fetch": "^2.6.7",
     "prettier": "^2.4.1",
     "tap-spec": "^5.0.0",
     "tape": "^4.13.0"

--- a/test.js
+++ b/test.js
@@ -7,7 +7,8 @@ const zarrRemote = require('./index')(fetch)
 const args = process.argv
 
 const urlLocal = 'data/'
-const urlRemote = 'https://storage.googleapis.com/carbonplan-share/testing/zarr-js/'
+const urlRemote =
+  'https://storage.googleapis.com/carbonplan-share/testing/zarr-js/'
 
 if (args.includes('local')) {
   run(zarrLocal, urlLocal, 'local')

--- a/test.js
+++ b/test.js
@@ -1,219 +1,257 @@
 const test = require('tape')
 const fs = require('fs/promises')
-const zarr = require('./index')(fs.readFile)
+const fetch = require('node-fetch')
+const zarrLocal = require('./index')(fs.readFile)
+const zarrRemote = require('./index')(fetch)
 
-test('1d.chunked.compressed.i2', function (t) {
-  zarr.load('data/1d.chunked.compressed.i2.zarr', (err, array) => {
-    t.deepEqual(array.data, new Int16Array([1, 2, 3, 4]))
-    t.end()
+const args = process.argv
+
+const urlLocal = 'data/'
+const urlRemote = 'https://storage.googleapis.com/carbonplan-share/testing/zarr-js/'
+
+if (args.includes('local')) {
+  run(zarrLocal, urlLocal, 'local')
+}
+if (args.includes('remote')) {
+  run(zarrRemote, urlRemote, 'remote')
+}
+
+function run(zarr, prefix, mode) {
+  test('1d.chunked.compressed.i2' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.chunked.compressed.i2.zarr', (err, array) => {
+      t.deepEqual(array.data, new Int16Array([1, 2, 3, 4]))
+      t.end()
+    })
   })
-})
 
-test('1d.chunked.filled.compressed.i2', function (t) {
-  zarr.load('data/1d.chunked.filled.compressed.i2.zarr', (err, array) => {
-    t.deepEqual(array.data, new Int16Array([1, 2, 0, 0]))
-    t.end()
+  test('1d.chunked.filled.compressed.i2' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.chunked.filled.compressed.i2.zarr', (err, array) => {
+      t.deepEqual(array.data, new Int16Array([1, 2, 0, 0]))
+      t.end()
+    })
   })
-})
 
-test('1d.contiguous.uncompressed.i2', function (t) {
-  zarr.load('data/1d.contiguous.uncompressed.i2.zarr', (err, array) => {
-    t.deepEqual(array.data, new Int16Array([1, 2, 3, 4]))
-    t.end()
+  test('1d.contiguous.uncompressed.i2' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.contiguous.uncompressed.i2.zarr', (err, array) => {
+      t.deepEqual(array.data, new Int16Array([1, 2, 3, 4]))
+      t.end()
+    })
   })
-})
 
-test('1d.contiguous.compressed.i4', function (t) {
-  zarr.load('data/1d.contiguous.compressed.i4.zarr', (err, array) => {
-    t.deepEqual(array.data, new Int32Array([1, 2, 3, 4]))
-    t.end()
+  test('1d.contiguous.compressed.i4' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.contiguous.compressed.i4.zarr', (err, array) => {
+      t.deepEqual(array.data, new Int32Array([1, 2, 3, 4]))
+      t.end()
+    })
   })
-})
 
-test('1d.contiguous.compressed.u1', function (t) {
-  zarr.load('data/1d.contiguous.compressed.u1.zarr', (err, array) => {
-    t.deepEqual(array.data, new Uint8Array([255, 0, 255, 0]))
-    t.end()
+  test('1d.contiguous.compressed.u1' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.contiguous.compressed.u1.zarr', (err, array) => {
+      t.deepEqual(array.data, new Uint8Array([255, 0, 255, 0]))
+      t.end()
+    })
   })
-})
 
-test('1d.contiguous.compressed.f4', function (t) {
-  zarr.load('data/1d.contiguous.compressed.f4.zarr', (err, array) => {
-    t.deepEqual(array.data, new Float32Array([-1000.5, 0, 1000.5, 0]))
-    t.end()
+  test('1d.contiguous.compressed.f4' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.contiguous.compressed.f4.zarr', (err, array) => {
+      t.deepEqual(array.data, new Float32Array([-1000.5, 0, 1000.5, 0]))
+      t.end()
+    })
   })
-})
 
-test('1d.contiguous.uncompressed.i4', function (t) {
-  zarr.load('data/1d.contiguous.uncompressed.i4.zarr', (err, array) => {
-    t.deepEqual(array.data, new Int32Array([1, 2, 3, 4]))
-    t.end()
+  test('1d.contiguous.uncompressed.i4' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.contiguous.uncompressed.i4.zarr', (err, array) => {
+      t.deepEqual(array.data, new Int32Array([1, 2, 3, 4]))
+      t.end()
+    })
   })
-})
 
-test('1d.contiguous.compressed.f8', function (t) {
-  zarr.load('data/1d.contiguous.compressed.f8.zarr', (err, array) => {
-    t.deepEqual(array.data, new Float64Array([1.5, 2.5, 3.5, 4.5]))
-    t.end()
+  test('1d.contiguous.compressed.f8' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.contiguous.compressed.f8.zarr', (err, array) => {
+      t.deepEqual(array.data, new Float64Array([1.5, 2.5, 3.5, 4.5]))
+      t.end()
+    })
   })
-})
 
-test('1d.contiguous.compressed.U13', function (t) {
-  zarr.load('data/1d.contiguous.compressed.U13.zarr', (err, array) => {
-    t.deepEqual(array.data, new Array('a', 'b', 'cc', 'd'))
-    t.end()
+  test('1d.contiguous.compressed.U13' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.contiguous.compressed.U13.zarr', (err, array) => {
+      t.deepEqual(array.data, new Array('a', 'b', 'cc', 'd'))
+      t.end()
+    })
   })
-})
 
-test('1d.contiguous.uncompressed.U13', function (t) {
-  zarr.load('data/1d.contiguous.compressed.U13.zarr', (err, array) => {
-    t.deepEqual(array.data, new Array('a', 'b', 'cc', 'd'))
-    t.end()
+  test('1d.contiguous.uncompressed.U13' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.contiguous.compressed.U13.zarr', (err, array) => {
+      t.deepEqual(array.data, new Array('a', 'b', 'cc', 'd'))
+      t.end()
+    })
   })
-})
 
-test('1d.contiguous.compressed.U7', function (t) {
-  zarr.load('data/1d.contiguous.compressed.U13.zarr', (err, array) => {
-    t.deepEqual(array.data, new Array('a', 'b', 'cc', 'd'))
-    t.end()
+  test('1d.contiguous.compressed.U7' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.contiguous.compressed.U13.zarr', (err, array) => {
+      t.deepEqual(array.data, new Array('a', 'b', 'cc', 'd'))
+      t.end()
+    })
   })
-})
 
-test('1d.contiguous.uncompressed.U7', function (t) {
-  zarr.load('data/1d.contiguous.compressed.U13.zarr', (err, array) => {
-    t.deepEqual(array.data, new Array('a', 'b', 'cc', 'd'))
-    t.end()
+  test('1d.contiguous.uncompressed.U7' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.contiguous.compressed.U13.zarr', (err, array) => {
+      t.deepEqual(array.data, new Array('a', 'b', 'cc', 'd'))
+      t.end()
+    })
   })
-})
 
-test('1d.contiguous.compressed.S7', function (t) {
-  zarr.load('data/1d.contiguous.compressed.U13.zarr', (err, array) => {
-    t.deepEqual(array.data, new Array('a', 'b', 'cc', 'd'))
-    t.end()
+  test('1d.contiguous.compressed.S7' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.contiguous.compressed.U13.zarr', (err, array) => {
+      t.deepEqual(array.data, new Array('a', 'b', 'cc', 'd'))
+      t.end()
+    })
   })
-})
 
-test('1d.contiguous.uncompressed.S7', function (t) {
-  zarr.load('data/1d.contiguous.compressed.U13.zarr', (err, array) => {
-    t.deepEqual(array.data, new Array('a', 'b', 'cc', 'd'))
-    t.end()
+  test('1d.contiguous.uncompressed.S7' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.contiguous.compressed.U13.zarr', (err, array) => {
+      t.deepEqual(array.data, new Array('a', 'b', 'cc', 'd'))
+      t.end()
+    })
   })
-})
 
-test('1d.contiguous.compressed.b1', function (t) {
-  zarr.load('data/1d.contiguous.compressed.b1.zarr', (err, array) => {
-    t.deepEqual(array.data, new Array(true, false, true, false))
-    t.end()
+  test('1d.contiguous.compressed.b1' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.contiguous.compressed.b1.zarr', (err, array) => {
+      t.deepEqual(array.data, new Array(true, false, true, false))
+      t.end()
+    })
   })
-})
 
-test('1d.contiguous.uncompressed.b1', function (t) {
-  zarr.load('data/1d.contiguous.compressed.b1.zarr', (err, array) => {
-    t.deepEqual(array.data, new Array(true, false, true, false))
-    t.end()
+  test('1d.contiguous.uncompressed.b1' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.contiguous.compressed.b1.zarr', (err, array) => {
+      t.deepEqual(array.data, new Array(true, false, true, false))
+      t.end()
+    })
   })
-})
 
-test('1d.contiguous.uncompressed.f8', function (t) {
-  zarr.load('data/1d.contiguous.uncompressed.f8.zarr', (err, array) => {
-    t.deepEqual(array.data, new Float64Array([1.5, 2.5, 3.5, 4.5]))
-    t.end()
+  test('1d.contiguous.uncompressed.f8' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.contiguous.uncompressed.f8.zarr', (err, array) => {
+      t.deepEqual(array.data, new Float64Array([1.5, 2.5, 3.5, 4.5]))
+      t.end()
+    })
   })
-})
 
-test('1d.chunked.compressed.i2', function (t) {
-  zarr.load('data/1d.chunked.compressed.i2.zarr', (err, array) => {
-    t.deepEqual(array.data, new Int16Array([1, 2, 3, 4]))
-    t.end()
+  test('1d.chunked.compressed.i2' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.chunked.compressed.i2.zarr', (err, array) => {
+      t.deepEqual(array.data, new Int16Array([1, 2, 3, 4]))
+      t.end()
+    })
   })
-})
 
-test('1d.chunked.ragged.compressed.i2', function (t) {
-  zarr.load('data/1d.chunked.ragged.compressed.i2.zarr', (err, array) => {
-    t.deepEqual(array.data, new Int16Array([1, 2, 3, 4, 5]))
-    t.end()
+  test('1d.chunked.ragged.compressed.i2' + `.${mode}`, function (t) {
+    zarr.load(prefix + '1d.chunked.ragged.compressed.i2.zarr', (err, array) => {
+      t.deepEqual(array.data, new Int16Array([1, 2, 3, 4, 5]))
+      t.end()
+    })
   })
-})
 
-test('2d.contiguous.compressed.i2', function (t) {
-  zarr.load('data/2d.contiguous.compressed.i2.zarr', (err, array) => {
-    t.deepEqual(array.data, new Int16Array([1, 2, 3, 4]))
-    t.deepEqual(array.shape, [2, 2])
-    t.end()
+  test('2d.contiguous.compressed.i2' + `.${mode}`, function (t) {
+    zarr.load(prefix + '2d.contiguous.compressed.i2.zarr', (err, array) => {
+      t.deepEqual(array.data, new Int16Array([1, 2, 3, 4]))
+      t.deepEqual(array.shape, [2, 2])
+      t.end()
+    })
   })
-})
 
-test('2d.chunked.compressed.i2', function (t) {
-  zarr.load('data/2d.chunked.compressed.i2.zarr', (err, array) => {
-    t.deepEqual(array.data, new Int16Array([1, 2, 3, 4]))
-    t.deepEqual(array.shape, [2, 2])
-    t.end()
+  test('2d.chunked.compressed.i2' + `.${mode}`, function (t) {
+    zarr.load(prefix + '2d.chunked.compressed.i2.zarr', (err, array) => {
+      t.deepEqual(array.data, new Int16Array([1, 2, 3, 4]))
+      t.deepEqual(array.shape, [2, 2])
+      t.end()
+    })
   })
-})
 
-test('2d.chunked.compressed.U7', function (t) {
-  zarr.load('data/2d.chunked.compressed.U7.zarr', (err, array) => {
-    t.deepEqual(array.data, new Array('a', 'b', 'cc', 'd'))
-    t.deepEqual(array.shape, [2, 2])
-    t.end()
+  test('2d.chunked.compressed.U7' + `.${mode}`, function (t) {
+    zarr.load(prefix + '2d.chunked.compressed.U7.zarr', (err, array) => {
+      t.deepEqual(array.data, new Array('a', 'b', 'cc', 'd'))
+      t.deepEqual(array.shape, [2, 2])
+      t.end()
+    })
   })
-})
 
-test('2d.chunked.filled.compressed.U7', function (t) {
-  zarr.load('data/2d.chunked.filled.compressed.U7.zarr', (err, array) => {
-    t.deepEqual(array.data, new Array('a', 'b', 'cc', ''))
-    t.deepEqual(array.shape, [2, 2])
-    t.end()
+  test('2d.chunked.filled.compressed.U7' + `.${mode}`, function (t) {
+    zarr.load(prefix + '2d.chunked.filled.compressed.U7.zarr', (err, array) => {
+      t.deepEqual(array.data, new Array('a', 'b', 'cc', ''))
+      t.deepEqual(array.shape, [2, 2])
+      t.end()
+    })
   })
-})
 
-test('2d.chunked.ragged.compressed.i2', function (t) {
-  zarr.load('data/2d.chunked.ragged.compressed.i2.zarr', (err, array) => {
-    t.deepEqual(array.data, new Int16Array([1, 2, 3, 4, 5, 6, 7, 8, 9]))
-    t.deepEqual(array.shape, [3, 3])
-    t.end()
+  test('2d.chunked.ragged.compressed.i2' + `.${mode}`, function (t) {
+    zarr.load(prefix + '2d.chunked.ragged.compressed.i2.zarr', (err, array) => {
+      t.deepEqual(array.data, new Int16Array([1, 2, 3, 4, 5, 6, 7, 8, 9]))
+      t.deepEqual(array.shape, [3, 3])
+      t.end()
+    })
   })
-})
 
-test('3d.chunked.compressed.i2', function (t) {
-  zarr.load('data/3d.chunked.compressed.i2.zarr', (err, array) => {
-    t.deepEqual(array.data, new Int16Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
-      14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]))
-    t.deepEqual(array.shape, [3, 3, 3])
-    t.end()
+  test('3d.chunked.compressed.i2' + `.${mode}`, function (t) {
+    zarr.load(prefix + '3d.chunked.compressed.i2.zarr', (err, array) => {
+      t.deepEqual(
+        array.data,
+        new Int16Array([
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+          20, 21, 22, 23, 24, 25, 26,
+        ])
+      )
+      t.deepEqual(array.shape, [3, 3, 3])
+      t.end()
+    })
   })
-})
 
-test('3d.contiguous.compressed.i2', function (t) {
-  zarr.load('data/3d.contiguous.compressed.i2.zarr', (err, array) => {
-    t.deepEqual(array.data, new Int16Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
-      14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]))
-    t.deepEqual(array.shape, [3, 3, 3])
-    t.end()
+  test('3d.contiguous.compressed.i2' + `.${mode}`, function (t) {
+    zarr.load(prefix + '3d.contiguous.compressed.i2.zarr', (err, array) => {
+      t.deepEqual(
+        array.data,
+        new Int16Array([
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+          20, 21, 22, 23, 24, 25, 26,
+        ])
+      )
+      t.deepEqual(array.shape, [3, 3, 3])
+      t.end()
+    })
   })
-})
 
-test('3d.chunked.mixed.compressed.i2', function (t) {
-  zarr.load('data/3d.chunked.mixed.compressed.i2.zarr', (err, array) => {
-    t.deepEqual(array.data, new Int16Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
-      14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]))
-    t.deepEqual(array.shape, [3, 3, 3])
-    t.end()
+  test('3d.chunked.mixed.compressed.i2' + `.${mode}`, function (t) {
+    zarr.load(prefix + '3d.chunked.mixed.compressed.i2.zarr', (err, array) => {
+      t.deepEqual(
+        array.data,
+        new Int16Array([
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+          20, 21, 22, 23, 24, 25, 26,
+        ])
+      )
+      t.deepEqual(array.shape, [3, 3, 3])
+      t.end()
+    })
   })
-})
 
-test('1d.contiguous.compressed.i2.group', function (t) {
-  zarr.loadGroup('data/1d.contiguous.compressed.i2.group.zarr', (err, group) => {
-    t.deepEqual(group.a.data, new Int16Array([1, 2, 3, 4]))
-    t.deepEqual(group.b.data, new Int16Array([5, 6, 7, 8]))
-    t.end()
+  test('1d.contiguous.compressed.i2.group' + `.${mode}`, function (t) {
+    zarr.loadGroup(
+      prefix + '1d.contiguous.compressed.i2.group.zarr',
+      (err, group) => {
+        t.deepEqual(group.a.data, new Int16Array([1, 2, 3, 4]))
+        t.deepEqual(group.b.data, new Int16Array([5, 6, 7, 8]))
+        t.end()
+      }
+    )
   })
-})
 
-test('1d.contiguous.compressed.i2.group.list', function (t) {
-  zarr.loadGroup('data/1d.contiguous.compressed.i2.group.zarr', (err, group) => {
-    t.deepEqual(group.a.data, new Int16Array([1, 2, 3, 4]))
-    t.equal(group.b, undefined)
-    t.end()
-  }, ['a'])
-})
+  test('1d.contiguous.compressed.i2.group.list' + `.${mode}`, function (t) {
+    zarr.loadGroup(
+      prefix + '1d.contiguous.compressed.i2.group.zarr',
+      (err, group) => {
+        t.deepEqual(group.a.data, new Int16Array([1, 2, 3, 4]))
+        t.equal(group.b, undefined)
+        t.end()
+      },
+      ['a']
+    )
+  })
+}


### PR DESCRIPTION
Working version with `fflate` to address https://github.com/freeman-lab/zarr-js/issues/16.

It turns out the problems we were encountering previously had to do with a difference between the object returned in the local vs remote code path, and the fact that `pako` was automatically (and quietly) doing a conversion that `fflate` was not. I updated the tests to include both local and remote fetching, which should make things more robust to future changes. And everything appears to be working!

Will publish as `2.2.1-develop.0` so @katamartin can do some testing.