### PR TITLE
Catch 403s in addition to 404s

### DIFF
--- a/src/v2.js
+++ b/src/v2.js
@@ -43,7 +43,7 @@ const zarr = (request) => {
         type === 'arraybuffer' &&
         response &&
         response.status &&
-        response.status === 404
+        [403, 404].includes(response.status)
       ) {
         return cb(null, null)
       } else {

--- a/src/v3.js
+++ b/src/v3.js
@@ -53,7 +53,7 @@ const zarr = (request, config = {}) => {
         type === 'arraybuffer' &&
         response &&
         response.status &&
-        response.status === 404
+        [403, 404].includes(response.status)
       ) {
         return cb(null, null)
       } else {


### PR DESCRIPTION
Closes https://github.com/freeman-lab/zarr-js/issues/67

Avoids erroring when expected 403s are returned from empty chunks in datasets in blob storage.
